### PR TITLE
fix: use localhost for internal_url, not fqdn

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,6 @@
 """A Juju charm for managing Kiali."""
 
 import logging
-import socket
 from pathlib import Path
 from typing import List
 from urllib.parse import urlparse
@@ -235,7 +234,7 @@ class KialiCharm(ops.CharmBase):
     @property
     def _internal_url(self) -> str:
         """Return the fqdn dns-based in-cluster (private) address of kiali."""
-        return f"{self._scheme}://{socket.getfqdn()}:{KIALI_PORT}"
+        return f"http://localhost:{KIALI_PORT}"
 
 
 # Helpers


### PR DESCRIPTION
#20 refactored `_internal_url` to use the service's fqdn.  This change reverts that.  The internal_url is used to check if the locally run kiali workload is serving its site - there's no benefit to going through kubernetes dns.  Also, Kiali's fqdn may not be reachable from this Pod due to AuthorizationPolicies, so using fqdn here is broken in some instances.
