### PR TITLE
feat: Integrate Tempo to Kiali (alternative approach)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -47,6 +47,12 @@ requires:
     interface: grafana_datasource
   service-mesh:
     interface: service_mesh
+  tempo-datasource-exchange:
+    interface: grafana_datasource_exchange
+    # limit 1 because we support connecting to only 1 tempo
+    limit: 1
+    description: |
+      Integration to receive information about where Tempo is used as a datasource
   require-cmr-mesh:
     interface: cross_model_mesh
   logging:


### PR DESCRIPTION
This is an alternative implementation to #31 which removes the collect_unit_status event handler entirely, putting everything in reconcile.  

Previously, the charm used:
* `reconcile` to reconcile the state managed by this charm, and
* `collect-unit-status` event to generate a holistic status based on the current state

This led to duplication between reconcile collect_status handlers.  `reconcile` implements a reconciliation code path (eg: if I have X config and Y config, start workloadA with those settings) and `collect_status` discects that code path, repeating some of that to produce a status that reflects that code path.  This is susceptible these functions getting out of sync (logic changes in reconcile and isn't reflected in collect_status) and makes it hard to update the charm later.

The current commit implements all this logic in reconcile only.  Reconcile attempts everything it can, collects any errors that result, and sets status/logs accordingly.