### PR TITLE
refactor: update how charm sets the unit status

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,19 @@
+"""Custom exceptions for this charm."""
+
+
+class ConfigurationError(Exception):
+    """Base exception for configuration errors."""
+
+    pass
+
+
+class ConfigurationBlockingError(ConfigurationError):
+    """Raised when a configuration error should result in a Blocked status."""
+
+    pass
+
+
+class ConfigurationWaitingError(ConfigurationError):
+    """Raised when a configuration error should result in a Waiting status."""
+
+    pass

--- a/src/status_manager.py
+++ b/src/status_manager.py
@@ -1,0 +1,42 @@
+"""Module for managing the status of a charm based on raised exceptions."""
+
+from typing import List
+
+from ops import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase, WaitingStatus
+
+
+def get_first_worst_status(statuses: List[StatusBase]) -> StatusBase:
+    """Return the first of the worst statuses in the list.
+
+    Raises if len(statuses) == 0.
+
+    Status are ranked, starting with the worst:
+        BlockedStatus
+        WaitingStatus
+        MaintenanceStatus
+        ActiveStatus
+    """
+    if len(statuses) == 0:
+        raise ValueError("No statuses provided")
+
+    blocked = None
+    waiting = None
+    maintenance = None
+    active = None
+
+    for status in statuses:
+        if isinstance(status, BlockedStatus):
+            blocked = status
+            # Escape immediately, as this is the worst status
+            break
+        if isinstance(status, WaitingStatus):
+            waiting = waiting or status
+        elif isinstance(status, MaintenanceStatus):
+            maintenance = maintenance or status
+        elif isinstance(status, ActiveStatus):
+            active = active or status
+
+    status = blocked or waiting or maintenance or active
+    if not status:
+        raise ValueError("No valid statuses provided")
+    return status


### PR DESCRIPTION
## Issue

Previously, unit status was handled in a collect_status event handler.  This meant that as we increased complexity of the reconcile function a lot of logic would need to be duplicated in the collect_status handler in order to give users a nuanced view of the charm status.

## Solution

To address this issue, the current commit refactors status handling to occur completely in the reconcile function.  To achieve this, the helpers called in `reconcile` will all raise custom exceptions on known errors.  These exceptions can be mapped to the desired charm statuses.  The benefit of this pattern is that we can embed the logic of "errorX should generate statusMessageY" in helpers without having helpers directly setting charm status

## Context
-

## Testing Instructions
No functional change is implemented.  Automated tests should cover everything

## Upgrade Notes
-