### PR TITLE
feat: integrate grafana

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -43,6 +43,9 @@ peers:
     interface: grafana_peers
 
 requires:
+  grafana-metadata:
+    interface: grafana_metadata
+    limit: 1
   ingress:
     interface: ingress
     limit: 1

--- a/lib/charms/grafana_k8s/v0/grafana_metadata.py
+++ b/lib/charms/grafana_k8s/v0/grafana_metadata.py
@@ -1,0 +1,221 @@
+"""grafana_metadata.
+
+This library implements endpoint wrappers for the grafana-metadata interface.  The grafana-metadata interface is used to
+transfer information about an instance of Grafana, such as how to access and uniquely identify it.  Typically, this is
+useful for charms that operate a Grafana instance to give other applications access to its API.
+
+## Usage
+
+### Requirer
+
+GrafanaMetadataRequirer is a wrapper for pulling data from the grafana-metadata interface.  To use it in your charm:
+
+* observe the relation-changed event for this relation wherever your charm needs to use this data (this endpoint wrapper
+  DOES NOT automatically observe any events)
+* wherever you need access to the data, call `GrafanaMetadataRequirer(...).get_data()`
+
+An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+
+        grafana_mnetadata = GrafanaMetadataRequirer(self.model.relations, "grafana-metadata")
+
+        self.framework.observe(self.on["grafana-metadata"].relation_changed, self._on_grafana_metadata_changed)
+
+    def _on_grafana_metadata_changed(self):
+        data = grafana_mnetadata.get_data()
+        ...
+```
+
+Where you also add relation to your `charmcraft.yaml` or `metadata.yaml` (note that GrafanaMetadataRequirer is designed
+for relating to a single application and must be used with limit=1 as shown below):
+
+```yaml
+requires:
+  grafana-metadata:
+    limit: 1
+    interface: grafana_metadata
+```
+
+### Provider
+
+GrafanaMetadataProvider is a wrapper for publishing data to charms related using the grafana-metadata interface.  Note
+that `GrafanaMetadataProvider` *does not* manage any events, but instead provides a `publish` method for sending data to
+all related applications.  Triggering `publish` appropriately is left to the charm author, although generally you want
+to do this at least during the `relation_joined` and `leader_elected` events.  An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.grafana_metadata = GrafanaMetadataProvider(
+            relations=self.model.relations,
+            relation_name="grafana-metadata",
+            app=self.app,
+        )
+
+        self.framework.observe(self.on.leader_elected, self.do_something_to_publish)
+        self.framework.observe(self._charm.on["grafana-metadata"].relation_joined, self.do_something_to_publish)
+        self.framework.observe(self.on.some_event_that_changes_grafana_metadata, self.do_something_to_publish)
+
+    def do_something_to_publish(self, e):
+        self.grafana_metadata.publish(...)
+```
+
+Where you also add the following to your `charmcraft.yaml` or `metadata.yaml`:
+
+```yaml
+provides:
+  grafana-metadata:
+    interface: grafana_metadata
+```
+"""
+
+import logging
+from typing import Optional
+
+from ops import RelationMapping, Application
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "cee305b7fe0546548cbfe81c3bd20e33"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+PYDEPS = ["pydantic>=2"]
+
+log = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "grafana-metadata"
+
+
+class GrafanaMetadataAppData(BaseModel):
+    """Data model for the grafana-metadata interface."""
+
+    ingress_url: Optional[AnyHttpUrl] = Field(
+        default=None,
+        description="The non-internal URL at which this application can be reached.  Typically, this is an ingress URL.",
+    )
+    direct_url: AnyHttpUrl = Field(
+        description="The cluster-internal URL at which this application can be reached.  Typically, this is a"
+        " Kubernetes FQDN like name.namespace.svc.cluster.local for connecting to the prometheus api"
+        " from inside the cluster, with scheme."
+    )
+    grafana_uid: str = Field(description="The UID of this Grafana application.")
+
+
+class GrafanaMetadataRequirer:
+    """Endpoint wrapper for the requirer side of the grafana-metadata relation."""
+
+    def __init__(
+        self,
+        relation_mapping: RelationMapping,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ) -> None:
+        """Initialize the GrafanaMetadataRequirer object.
+
+        This object is for accessing data from relations that use the grafana-metadata interface.  It **does not**
+        autonomously handle the events associated with that relation.  It is up to the charm using this object to
+        observe those events as they see fit.  Typically, that charm should observe this relation's relation-changed
+        event.
+
+        This object is for interacting with a relation that has limit=1 set in charmcraft.yaml.  In particular, the
+        get_data method will raise if more than one related application is available.
+
+        Args:
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm
+                              object).
+            relation_name: The name of the wrapped relation.
+        """
+        self._charm_relation_mapping = relation_mapping
+        self._relation_name = relation_name
+
+    @property
+    def relations(self):
+        """Return the relation instances for applications related to us on the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, ())
+
+    # TODO: This line was modified locally to fix a typing error in the lib.  Revert this change once that is fixed.
+    def get_data(self) -> Optional[GrafanaMetadataAppData]:
+        """Return data for at most one related application, raising if more than one is available.
+
+        Useful for charms that always expect exactly one related application.  It is recommended that those charms also
+        set limit=1 for that relation in charmcraft.yaml.  Returns None if no data is available (either because no
+        applications are related to us, or because the related application has not sent data).
+        """
+        relations = self.relations
+        if len(relations) == 0:
+            return None
+        if len(relations) > 1:
+            raise ValueError("Cannot get_info when more than one application is related.")
+
+        # Being a little cautious here using getattr and get, since some funny things have happened with relation data
+        # in the past.
+        raw_data_dict = getattr(relations[0], "data", {}).get(relations[0].app)
+        if not raw_data_dict:
+            return None
+
+        return GrafanaMetadataAppData.model_validate(raw_data_dict)
+
+
+class GrafanaMetadataProvider:
+    """The provider side of the grafana-metadata relation."""
+
+    def __init__(
+        self,
+        relation_mapping: RelationMapping,
+        app: Application,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Initialize the GrafanaMetadataProvider object.
+
+        This object is for serializing and sending data to a relation that uses the grafana-metadata interface - it does
+        not automatically observe any events for that relation.  It is up to the charm using this to call publish when
+        it is appropriate to do so, typically on at least the charm's leader_elected event and this relation's
+        relation_joined event.
+
+        Args:
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm object).
+            app: This application.
+            relation_name: The name of the relation.
+        """
+        self._charm_relation_mapping = relation_mapping
+        self._app = app
+        self._relation_name = relation_name
+
+    @property
+    def relations(self):
+        """Return the applications related to us under the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, ())
+
+    def publish(
+        self, grafana_uid: str, direct_url: AnyHttpUrl, ingress_url: Optional[AnyHttpUrl] = None
+    ):
+        """Post grafana-metadata to all related applications.
+
+        This method writes to the relation's app data bag, and thus should never be called by a unit that is not the
+        leader otherwise ops will raise an exception.
+
+        Args:
+            grafana_uid: The UID of this Grafana instance.
+            direct_url: The cluster-internal URL at which this application can be reached.  Typically, this is a
+                        Kubernetes FQDN like name.namespace.svc.cluster.local for connecting to the prometheus api
+                        from inside the cluster, with scheme.
+            ingress_url: The non-internal URL at which this application can be reached.  Typically, this is an ingress
+                         URL.
+        """
+        data = GrafanaMetadataAppData(
+            grafana_uid=grafana_uid, direct_url=direct_url, ingress_url=ingress_url
+        ).model_dump(mode="json", by_alias=True, exclude_defaults=True, round_trip=True)
+
+        for relation in self.relations:
+            databag = relation.data[self._app]
+            databag.update(data)

--- a/src/charm.py
+++ b/src/charm.py
@@ -127,7 +127,7 @@ class KialiCharm(ops.CharmBase):
                 grafana_urls = self._get_grafana_urls()
                 grafana_internal_url = grafana_urls["internal_url"]
                 grafana_external_url = grafana_urls["external_url"]
-            except BlockedStatusError:
+            except GrafanaMissingError:
                 # Grafana integration is optional for the charm.  If the relation is Blocked (eg: does not exist) the
                 # charm will log and ignore it.  But if the relation is Waiting, we catch the status normally.
                 grafana_internal_url = None
@@ -281,12 +281,12 @@ class KialiCharm(ops.CharmBase):
         If GrafanaMetadataAppData.ingress_url is not available, it will default to GrafanaMetadataAppData.direct_url.
 
         Raises:
-          ConfigurationBlockingError: If no grafana is related to this application
-          ConfigurationWaitingError: If a grafana is related to this application, but its data is incomplete.
+          GrafanaMissingError: If no grafana is related to this application
+          WaitingStatusError: If a grafana is related to this application, but its data is incomplete.
         """
         LOGGER.debug("Getting Grafana configuration")
         if len(self._grafana_metadata.relations) == 0:
-            raise BlockedStatusError("No grafana available over the grafana-metadata relation")
+            raise GrafanaMissingError("No grafana available over the grafana-metadata relation")
 
         grafana_metadata = self._grafana_metadata.get_data()
         if not grafana_metadata:
@@ -414,6 +414,12 @@ def _is_kiali_available(kiali_url):
 
 class PrometheusSourceError(Exception):
     """Raised when the Prometheus data is not available."""
+
+    pass
+
+
+class GrafanaMissingError(Exception):
+    """Raised when the Grafana data is not available."""
 
     pass
 

--- a/src/workload_config.py
+++ b/src/workload_config.py
@@ -58,7 +58,9 @@ class GrafanaConfig(BaseModel):
     """Configuration for Grafana service."""
 
     enabled: bool = False
-    external_url: Optional[str] = None
+    # This is used by Kiali to present links to the user.  It should be accessible to the user.
+    internal_url: str
+    external_url: str
 
 
 class ExternalServicesConfig(BaseModel):

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -3,42 +3,62 @@
 # See LICENSE file for licensing details.
 from contextlib import nullcontext as does_not_raise
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from observability_charm_tools.exceptions import BlockedStatusError, WaitingStatusError
 from ops import ActiveStatus, BlockedStatus, WaitingStatus
 from scenario import Container, Relation, State
 
-REMOTE_PROMETHEUS_APP_NAME = "grafana"
+from charm import KialiCharm
+
 REMOTE_PROMETHEUS_MODEL = "some-model"
 REMOTE_PROMETHEUS_MODEL_UUID = "1"
 REMOTE_PROMETHEUS_TYPE = "prometheus"
-REMOTE_PROMETHEUS_URL = "http://prometheus:9090"
+REMOTE_PROMETHEUS_URL = "http://prometheus:9090/"
 REMOTE_ISTIO_APP_NAME = "istio"
 REMOTE_ISTIO_NAMESPACE = "istio-model"
+GRAFANA_INTERNAL_URL = "http://grafana:3000/"
+GRAFANA_EXTERNAL_URL = "http://grafana.example.com/"
+GRAFANA_UID = "grafana-uid"
 
 
-def mock_prometheus_relation() -> Relation:
-    """Return a mock relation to prometheus."""
+def mock_grafana_relation(
+    internal_url=GRAFANA_INTERNAL_URL, external_url=GRAFANA_EXTERNAL_URL
+) -> Relation:
+    """Return a mock relation to grafana."""
     return Relation(
-        endpoint="prometheus",
-        interface="prometheus_api",
-        remote_app_name=REMOTE_PROMETHEUS_APP_NAME,
+        endpoint="grafana-metadata",
+        interface="grafana_metadata",
+        remote_app_name="grafana",
         remote_app_data={
-            "direct_url": REMOTE_PROMETHEUS_URL,
+            "direct_url": internal_url,
+            "ingress_url": external_url,
+            "grafana_uid": GRAFANA_UID,
         },
     )
 
 
-def mock_istio_metadata_relation() -> Relation:
+def mock_prometheus_relation(direct_url=REMOTE_PROMETHEUS_URL) -> Relation:
+    """Return a mock relation to prometheus."""
+    return Relation(
+        endpoint="prometheus",
+        interface="prometheus_api",
+        remote_app_name="prometheus",
+        remote_app_data={
+            "direct_url": direct_url,
+        },
+    )
+
+
+def mock_istio_metadata_relation(root_namespace=REMOTE_ISTIO_NAMESPACE) -> Relation:
     """Return a mock relation for istio-metadata."""
     return Relation(
         endpoint="istio-metadata",
         interface="istio_metadata",
-        remote_app_name=REMOTE_ISTIO_APP_NAME,
+        remote_app_name="istio",
         remote_app_data={
-            "root_namespace": REMOTE_ISTIO_NAMESPACE,
+            "root_namespace": root_namespace,
         },
     )
 
@@ -58,7 +78,7 @@ def mock_is_kiali_available(raises: Optional[Exception]):
     "container, relations, kiali_available_mock, expected_status",
     [
         (
-            # Has all inputs - Active
+            # Has prometheus and istio-metadata - Active
             Container(name="kiali", can_connect=True),
             [
                 mock_prometheus_relation(),
@@ -125,17 +145,45 @@ def test_charm_given_inputs(
 
 
 @pytest.mark.parametrize(
-    "prometheus_url, istio_namespace, expected, expected_context",
+    "prometheus_url, istio_namespace, grafana_internal_url, grafana_external_url, expected, expected_context",
     [
         (
             # Active: All inputs provided.
-            "http://prometheus:9090",
-            "istio-namespace",
+            REMOTE_PROMETHEUS_URL,
+            REMOTE_ISTIO_NAMESPACE,
+            # Include a trailing slash here to ensure we remove them during parsing.  Kiali doesn't accept trailing
+            # slashes
+            GRAFANA_INTERNAL_URL,
+            GRAFANA_EXTERNAL_URL,
             {
                 "auth": {"strategy": "anonymous"},
                 "deployment": {"view_only_mode": True},
-                "external_services": {"prometheus": {"url": REMOTE_PROMETHEUS_URL}},
-                "istio_namespace": "istio-namespace",
+                "external_services": {
+                    "prometheus": {"url": REMOTE_PROMETHEUS_URL},
+                    "grafana": {
+                        "enabled": True,
+                        "internal_url": GRAFANA_INTERNAL_URL.rstrip("/"),
+                        "external_url": GRAFANA_EXTERNAL_URL.rstrip("/"),
+                    },
+                },
+                "istio_namespace": REMOTE_ISTIO_NAMESPACE,
+                "server": {"port": 20001, "web_root": "/"},
+            },
+            does_not_raise(),
+        ),
+        (
+            # Active: All inputs except optional grafana provided.
+            REMOTE_PROMETHEUS_URL,
+            REMOTE_ISTIO_NAMESPACE,
+            None,
+            None,
+            {
+                "auth": {"strategy": "anonymous"},
+                "deployment": {"view_only_mode": True},
+                "external_services": {
+                    "prometheus": {"url": REMOTE_PROMETHEUS_URL},
+                },
+                "istio_namespace": REMOTE_ISTIO_NAMESPACE,
                 "server": {"port": 20001, "web_root": "/"},
             },
             does_not_raise(),
@@ -145,11 +193,15 @@ def test_charm_given_inputs(
             None,
             "istio-namespace",
             None,
+            None,
+            None,
             pytest.raises(BlockedStatusError),
         ),
         (
             # Inactive: Missing istio namespace should raise an exception.
             "http://prometheus:9090",
+            None,
+            None,
             None,
             None,
             pytest.raises(BlockedStatusError),
@@ -161,6 +213,8 @@ def test_kiali_config(
     this_charm_context,
     prometheus_url,
     istio_namespace,
+    grafana_internal_url,
+    grafana_external_url,
     expected,
     expected_context,
 ):
@@ -170,7 +224,76 @@ def test_kiali_config(
         # Default value in case we raise an exception
         with expected_context:
             kiali_config = charm._generate_kiali_config(
-                prometheus_url=prometheus_url, istio_namespace=istio_namespace
+                prometheus_url=prometheus_url,
+                istio_namespace=istio_namespace,
+                grafana_internal_url=grafana_internal_url,
+                grafana_external_url=grafana_external_url,
             )
             # If above doesn't raise, compare output
             assert kiali_config == expected
+
+
+@pytest.mark.parametrize(
+    "prometheus_relation, istio_metadata_relation, grafana_metadata_relation",
+    [
+        (
+            mock_prometheus_relation(direct_url=REMOTE_PROMETHEUS_URL),
+            mock_istio_metadata_relation(root_namespace=REMOTE_ISTIO_NAMESPACE),
+            None,
+        ),
+        (
+            mock_prometheus_relation(direct_url=REMOTE_PROMETHEUS_URL),
+            mock_istio_metadata_relation(root_namespace=REMOTE_ISTIO_NAMESPACE),
+            mock_grafana_relation(
+                internal_url=GRAFANA_INTERNAL_URL, external_url=GRAFANA_EXTERNAL_URL
+            ),
+        ),
+    ],
+)
+def test_e2e_charm_configuration(
+    this_charm_context, prometheus_relation, istio_metadata_relation, grafana_metadata_relation
+):
+    """An end-to-end spot test confirming configuration is correctly passed from relations to _generate_kiali_config."""
+    # Arrange
+    relations = []
+    prometheus_url_expected = None
+    istio_namespace_expected = None
+    grafana_internal_url_expected = None
+    grafana_external_url_expected = None
+
+    if prometheus_relation:
+        relations.append(prometheus_relation)
+        prometheus_url_expected = prometheus_relation.remote_app_data["direct_url"]
+    if istio_metadata_relation:
+        relations.append(istio_metadata_relation)
+        istio_namespace_expected = istio_metadata_relation.remote_app_data["root_namespace"]
+    if grafana_metadata_relation:
+        relations.append(grafana_metadata_relation)
+        # remove the trailing slash, as we intentionally strip it out to keep Kiali happy
+        grafana_internal_url_expected = grafana_metadata_relation.remote_app_data["direct_url"]
+        grafana_external_url_expected = grafana_metadata_relation.remote_app_data["ingress_url"]
+
+    state = State(
+        containers=[
+            Container(name="kiali", can_connect=True),
+        ],
+        relations=relations,
+        leader=True,
+    )
+
+    # Act
+    with this_charm_context(this_charm_context.on.config_changed(), state) as manager:
+        charm: KialiCharm = manager.charm
+        mock_generate_kiali_config = MagicMock()
+        charm._generate_kiali_config = mock_generate_kiali_config
+        # We don't need to actually configure anything
+        charm._configure_kiali_workload = MagicMock()
+        manager.run()
+
+        # Assert
+        mock_generate_kiali_config.assert_called_once_with(
+            prometheus_url=prometheus_url_expected,
+            istio_namespace=istio_namespace_expected,
+            grafana_internal_url=grafana_internal_url_expected,
+            grafana_external_url=grafana_external_url_expected,
+        )


### PR DESCRIPTION
**NOTE:** After implementing this feature I realized during final manual testing that Kiali actually needs **authenticated access** to Grafana.  If it fails to access grafana (no password, bad link, etc) it does not provide links in the dashboard, even if we provide all the other details.  This means that if auth is enabled in Grafana we also need to provide grafana creds to Kiali.

Setting up a programmatic login in Grafana is out of scope for this PR, so for now I suggest we land this PR as is and later build the auth handling features.   Unfortunately, most of the benefits of Grafana integration in Kiali wont actually work until that is done, but we need this anyway when integrating Tempo so we might as well land it...

## Issue
Kiali can provide users with links to Grafana for a deeper dive into Istio's metrics. 
 Previously, charmed kiali did not configure these

## Solution
Add integration to grafana using the grafana-metadata interface.

Not included here is setting up authentication between Kiali and Grafana.  See https://github.com/canonical/kiali-k8s-operator/issues/43 for more details.  This means that while the integration exists, it may not provide all functionality unless related to an unauthenticated Grafana.

## Context
.

## Testing Instructions
See #43 for some hacky manual integration tests.  tbh I don't think its worth it, since we need further work after this to actually make it useful. 

## Upgrade Notes
.