### PR TITLE
feat: bump kiali to version 2.7.1

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -96,4 +96,4 @@ resources:
   kiali-image:
     type: oci-image
     description: Kiali OCI image
-    upstream-source: quay.io/kiali/kiali:v2.2.0
+    upstream-source: quay.io/kiali/kiali:v2.7.1


### PR DESCRIPTION
## Issue
Previous to this PR we used Kiali 2.2.0.  The recent minor releases of Kiali add a lot of features around Istio Ambient mesh that make it much more capable.

## Solution
Bump to 2.7.1

## Context


## Testing Instructions
I've manually tested by refreshing an existing kiali.  Integration tests should cover this already

## Upgrade Notes
