### PR TITLE
feat: integrate tempo to kiali

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,0 +1,1 @@
+tests/integration/test_tempo_integration.py

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -63,6 +63,9 @@ requires:
     interface: cross_model_mesh
   service-mesh:
     interface: service_mesh
+  tempo-api:
+    interface: tempo_api
+    limit: 1
 
 provides:
   provide-cmr-mesh:
@@ -71,6 +74,12 @@ provides:
     interface: prometheus_scrape
     description: |
       Exposes the Prometheus metrics endpoint providing telemetry about the Kiali instance
+  tempo-datasource-exchange:
+    interface: grafana_datasource_exchange
+    # limit 1 because we support connecting to only 1 tempo
+    limit: 1
+    description: |
+      Integration to receive information about where Tempo is used as a datasource
 
 config:
   options:

--- a/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tempo_api.py
@@ -1,0 +1,289 @@
+"""tempo_api.
+
+This library implements endpoint wrappers for the tempo-api interface.  The tempo-api interface is used to
+transfer information about an instance of Tempo, such as how to access and uniquely identify it.  Typically, this is
+useful for charms that operate a Tempo instance to give other applications access to
+[Tempo's HTTP API](https://grafana.com/docs/tempo/latest/api_docs/).
+
+## Usage
+
+### Requirer
+
+TempoApiRequirer is a wrapper for pulling data from the tempo-api interface.  To use it in your charm:
+
+* observe the relation-changed event for this relation wherever your charm needs to use this data (this endpoint wrapper
+  DOES NOT automatically observe any events)
+* wherever you need access to the data, call `TempoApiRequirer(...).get_data()`
+
+An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+
+        tempo_api = TempoApiRequirer(self.model.relations, "tempo-api")
+
+        self.framework.observe(
+            self.on["tempo-api"].relation_changed, self._on_tempo_api_changed
+        )
+
+    def do_something_with_metadata(self):
+        data = tempo_api.get_data()
+        ...
+```
+
+Where you also add relation to your `charmcraft.yaml` or `metadata.yaml` (note that TempoApiRequirer is designed for
+relating to a single application and must be used with limit=1 as shown below):
+
+```yaml
+requires:
+  tempo-api:
+    limit: 1
+    interface: tempo_api
+```
+
+### Provider
+
+TempoApiProvider is a wrapper for publishing data to charms related using the tempo-api interface.  Note that
+`TempoApiProvider` *does not* manage any events, but instead provides a `publish` method for sending data to
+all related applications.  Triggering `publish` appropriately is left to the charm author, although generally you want
+to do this at least during the `relation_joined` and `leader_elected` events.  An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.tempo_api = TempoApiProvider(
+            relations=self.model.relations,
+            relation_name="tempo-api",
+            app=self.app,
+        )
+
+        self.framework.observe(self.on.leader_elected, self.do_something_to_publish)
+        self.framework.observe(
+            self._charm.on["tempo-api"].relation_joined, self.do_something_to_publish
+        )
+        self.framework.observe(
+            self.on.some_event_that_changes_tempos_url, self.do_something_to_publish
+        )
+
+    def do_something_to_publish(self, e):
+        self.tempo_api.publish(...)
+```
+
+Where you also add the following to your `charmcraft.yaml` or `metadata.yaml`:
+
+```yaml
+provides:
+  tempo-api:
+    interface: tempo_api
+```
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional, Union
+
+import yaml
+from ops import Application, Relation, RelationMapping
+from pydantic import AfterValidator, AnyHttpUrl, BaseModel, Field
+from typing_extensions import Annotated
+
+# The unique Charmhub library identifier, never change it
+LIBID = "6d55454c9a104113b2bd01e738dd5f99"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+PYDEPS = ["pydantic>=2"]
+
+log = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "tempo-api"
+
+# Define a custom type that accepts AnyHttpUrl and string, but converts to AnyHttpUrl and raises an exception if the
+# string is not a valid URL
+AnyHttpUrlOrStrUrl = Annotated[Union[AnyHttpUrl, str], AfterValidator(lambda v: AnyHttpUrl(v))]
+
+
+class TempoApiUrls(BaseModel):
+    """Data model for urls Tempo offers for query access, for a given protocol."""
+
+    direct_url: AnyHttpUrlOrStrUrl = Field(
+        description="The cluster-internal URL at which this application can be reached for a connection."
+        " Typically, this is a Kubernetes FQDN like name.namespace.svc.cluster.local for"
+        " connecting to the tempo api from inside the cluster, with scheme and maybe port."
+    )
+    ingress_url: Optional[AnyHttpUrlOrStrUrl] = Field(
+        default=None,
+        description="The non-internal URL at which this application can be reached for a connection."
+        " Typically, this is an ingress URL.",
+    )
+
+
+class TempoApiAppData(BaseModel):
+    """Data model for the tempo-api interface."""
+
+    http: TempoApiUrls = Field(
+        description="The URLs at which this application can be reached for an http connection to query Tempo."
+    )
+    grpc: TempoApiUrls = Field(
+        description="The URLs at which this application can be reached for an http connection to query Tempo."
+    )
+
+
+class TempoApiRequirer:
+    """Endpoint wrapper for the requirer side of the tempo-api relation."""
+
+    def __init__(
+        self,
+        relation_mapping: RelationMapping,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ) -> None:
+        """Initialize the TempoApiRequirer object.
+
+        This object is for accessing data from relations that use the tempo-api interface.  It **does not**
+        autonomously handle the events associated with that relation.  It is up to the charm using this object to
+        observe those events as they see fit.  Typically, that charm should observe this relation's relation-changed
+        event.
+
+        This object requires the relation has limit=1 set in charmcraft.yaml, otherwise it will raise a ValueError
+        exception.
+
+        Args:
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm
+                              object).
+            relation_name: The name of the wrapped relation.
+        """
+        self._charm_relation_mapping = relation_mapping
+        self._relation_name = relation_name
+
+        self._validate_relation_metadata()
+
+    @property
+    def relations(self) -> List[Relation]:
+        """Return the relation instances for applications related to us on the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, [])
+
+    # TODO: Revert the below manual change once https://github.com/canonical/tempo-coordinator-k8s-operator/pull/142
+    #  lands
+    def get_data(self) -> Optional[TempoApiAppData]:
+        """Return data from the relation.
+
+        Returns None if no data is available, either because no applications are related to us, or because the related
+        application has not sent data.  To distinguish between these cases, check if
+        len(tempo_api_requirer.relations)==0.
+        """
+        relations = self.relations
+        if len(relations) == 0:
+            return None
+
+        # Being a little cautious here using getattr and get, since some funny things have happened with relation data
+        # in the past.
+        raw_data_dict = getattr(relations[0], "data", {}).get(relations[0].app)
+        if not raw_data_dict:
+            return None
+
+        # The data in the databag is in format [str: json-string-of-dict].  Expand out those nested JSON dicts so we
+        # have the full object
+        raw_data_dict = {k: json.loads(v) for k, v in raw_data_dict.items()}
+
+        return TempoApiAppData.model_validate(raw_data_dict)
+
+    def _validate_relation_metadata(self):
+        """Validate that the provided relation has the correct metadata for this endpoint."""
+        charm_root = Path(__file__).absolute().parents[4]
+        # Do not check charmcraft.yaml, just metadata.yaml.  metadata.yaml is the only file that will be present in a
+        # running charm, and this validation step fails during unit testing anyway so we'll never need to look at
+        # charmcraft.yaml
+        try:
+            yaml_raw = (charm_root / "metadata.yaml").read_text()
+            relation = yaml.safe_load(yaml_raw)["requires"][self._relation_name]
+        except KeyError as e:
+            raise ValueError(
+                f"Relation '{self._relation_name}' not found in metadata.yaml."
+            ) from e
+
+        if relation.get("limit", None) != 1:
+            raise ValueError(
+                "TempoApiRequirer is designed for relating to a single application and must be used with limit=1."
+            )
+
+
+class TempoApiProvider:
+    """The provider side of the tempo-api relation."""
+
+    def __init__(
+        self,
+        relation_mapping: RelationMapping,
+        relation_name: str,
+        app: Application,
+    ):
+        """Initialize the TempoApiProvider object.
+
+        This object is for serializing and sending data to a relation that uses the tempo-api interface - it does
+        not automatically observe any events for that relation.  It is up to the charm using this to call publish when
+        it is appropriate to do so, typically on at least the charm's leader_elected event and this relation's
+        relation_joined event.
+
+        Args:
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm
+                              object).
+            app: This application.
+            relation_name: The name of the wrapped relation.
+        """
+        self._charm_relation_mapping = relation_mapping
+        self._app = app
+        self._relation_name = relation_name
+
+    @property
+    def relations(self):
+        """Return the applications related to us under the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, ())
+
+    def publish(
+        self,
+        direct_url_http: Union[AnyHttpUrl, str],
+        direct_url_grpc: Union[AnyHttpUrl, str],
+        ingress_url_http: Optional[Union[AnyHttpUrl, str]] = None,
+        ingress_url_grpc: Optional[Union[AnyHttpUrl, str]] = None,
+    ):
+        """Post tempo-api to all related applications.
+
+        This method writes to the relation's app data bag, and thus should never be called by a unit that is not the
+        leader otherwise ops will raise an exception.
+
+        Args:
+            direct_url_http: The cluster-internal URL at which this application can be reached for an http connection.
+                             Typically, this is a Kubernetes FQDN like name.namespace.svc.cluster.local for
+                             connecting to the tempo http api from inside the cluster, with scheme and maybe port.
+            direct_url_grpc: The cluster-internal URL at which this application can be reached for a grpc connection.
+                             Typically, this is a Kubernetes FQDN like name.namespace.svc.cluster.local for
+                             connecting to the tempo grpc api from inside the cluster, with scheme.
+            ingress_url_http: The non-internal URL at which this application can be reached for an http connection.
+                              Typically, this is an ingress URL.
+            ingress_url_grpc: The non-internal URL at which this application can be reached for a grpc connection.
+                              Typically, this is an ingress URL.
+        """
+        data = TempoApiAppData(
+            http=TempoApiUrls(
+                direct_url=direct_url_http,
+                ingress_url=ingress_url_http,
+            ),
+            grpc=TempoApiUrls(
+                direct_url=direct_url_grpc,
+                ingress_url=ingress_url_grpc,
+            ),
+        ).model_dump(mode="json", by_alias=True, exclude_defaults=True, round_trip=True)
+        # Flatten any nested objects, since relation databags are str:str mappings
+        data = {k: json.dumps(v) for k, v in data.items()}
+
+        for relation in self.relations:
+            databag = relation.data[self._app]
+            databag.update(data)

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,13 +13,15 @@ from urllib.parse import urlparse
 import ops
 import requests
 import yaml
-from charms.grafana_k8s.v0.grafana_metadata import GrafanaMetadataRequirer
+from charms.grafana_k8s.v0.grafana_metadata import GrafanaMetadataAppData, GrafanaMetadataRequirer
 from charms.istio_beacon_k8s.v0.service_mesh import ServiceMeshConsumer
 from charms.istio_k8s.v0.istio_metadata import IstioMetadataRequirer
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.mimir_coordinator_k8s.v0.prometheus_api import PrometheusApiRequirer
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from charms.tempo_coordinator_k8s.v0.tempo_api import TempoApiAppData, TempoApiRequirer
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from cosl.interfaces.datasource_exchange import DatasourceExchange
 from observability_charm_tools.exceptions import BlockedStatusError, WaitingStatusError
 from observability_charm_tools.status_handling import StatusManager
 from ops import Container, Port, pebble
@@ -34,6 +36,8 @@ from workload_config import (
     KialiConfigSpec,
     PrometheusConfig,
     ServerConfig,
+    TracingConfig,
+    TracingTempoConfig,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -46,6 +50,8 @@ KIALI_PEBBLE_SERVICE_NAME = "kiali"
 ISTIO_RELATION = "istio-metadata"
 PROMETHEUS_RELATION = "prometheus"
 GRAFANA_RELATION = "grafana-metadata"
+TEMPO_API_RELATION = "tempo-api"
+TEMPO_DATASOURCE_EXCHANGE_RELATION = "tempo-datasource-exchange"
 
 
 class GrafanaUrls(TypedDict):
@@ -53,6 +59,14 @@ class GrafanaUrls(TypedDict):
 
     internal_url: str
     external_url: str
+
+
+class TempoConfigurationData(TypedDict):
+    """The configuration data for the Tempo datasource in Kiali."""
+
+    datasource_uid: str
+    external_url: str
+    internal_url: str
 
 
 class KialiCharm(ops.CharmBase):
@@ -108,6 +122,24 @@ class KialiCharm(ops.CharmBase):
         self.framework.observe(self.on[GRAFANA_RELATION].relation_changed, self.reconcile)
         self.framework.observe(self.on[GRAFANA_RELATION].relation_broken, self.reconcile)
 
+        # Integrating Tempo as a datasource for Kiali
+        self._tempo_api = TempoApiRequirer(
+            relation_mapping=self.model.relations, relation_name=TEMPO_API_RELATION
+        )
+        self.framework.observe(self.on[TEMPO_API_RELATION].relation_changed, self.reconcile)
+        self.framework.observe(self.on[TEMPO_API_RELATION].relation_broken, self.reconcile)
+        self._tempo_datasource_exchange = DatasourceExchange(
+            charm=self,
+            provider_endpoint=TEMPO_DATASOURCE_EXCHANGE_RELATION,
+            requirer_endpoint=None,
+        )
+        self.framework.observe(
+            self.on[TEMPO_DATASOURCE_EXCHANGE_RELATION].relation_changed, self.reconcile
+        )
+        self.framework.observe(
+            self.on[TEMPO_DATASOURCE_EXCHANGE_RELATION].relation_broken, self.reconcile
+        )
+
     def reconcile(self, _event: ops.ConfigChangedEvent):
         """Reconcile the entire state of the charm."""
         LOGGER.debug("Reconciling Kiali charm")
@@ -122,17 +154,23 @@ class KialiCharm(ops.CharmBase):
         with status_manager:
             istio_namespace = self._get_istio_namespace()
 
+        grafana_internal_url = None
+        grafana_external_url = None
+        grafana_uid = None
         with status_manager:
             try:
-                grafana_urls = self._get_grafana_urls()
-                grafana_internal_url = grafana_urls["internal_url"]
-                grafana_external_url = grafana_urls["external_url"]
+                grafana_metadata = self._get_grafana_metadata()
+                grafana_internal_url = str(grafana_metadata.direct_url)
+                grafana_external_url = str(grafana_metadata.ingress_url)
+                grafana_uid = grafana_metadata.grafana_uid
             except GrafanaMissingError:
                 # Grafana integration is optional for the charm.  If the relation is Blocked (eg: does not exist) the
                 # charm will log and ignore it.  But if the relation is Waiting, we catch the status normally.
-                grafana_internal_url = None
-                grafana_external_url = None
                 LOGGER.info("Grafana integration disabled - no grafana relation found.")
+
+        tempo_configuration = None
+        with status_manager:
+            tempo_configuration = self._get_tempo_configuration(grafana_uid=grafana_uid)
 
         kiali_config = None
         with status_manager:
@@ -141,6 +179,7 @@ class KialiCharm(ops.CharmBase):
                 istio_namespace=istio_namespace,
                 grafana_internal_url=grafana_internal_url,
                 grafana_external_url=grafana_external_url,
+                tempo_configuration=tempo_configuration,
             )
 
         with status_manager:
@@ -195,6 +234,7 @@ class KialiCharm(ops.CharmBase):
         istio_namespace: Optional[str],
         grafana_internal_url: Optional[str],
         grafana_external_url: Optional[str],
+        tempo_configuration: Optional[TempoConfigurationData],
     ) -> dict:
         """Generate the Kiali configuration."""
         LOGGER.debug("Generating Kiali configuration")
@@ -205,23 +245,6 @@ class KialiCharm(ops.CharmBase):
             raise BlockedStatusError("Cannot configure Kiali - no related istio available")
 
         external_services = ExternalServicesConfig(prometheus=PrometheusConfig(url=prometheus_url))
-
-        # TODO: implement _get_tempo_source_url()
-        # tempo_url = self._get_tempo_source_url()
-        # if tempo_url:
-        #     external_services.tracing = TracingConfig(
-        #         enabled=True,
-        #         internal_url=tempo_url,
-        #         use_grpc=True,
-        #         external_url=tempo_url,
-        #         grpc_port=9096,
-        # TODO: work on below functionality when we figure out how to get tempo's grafana source uid
-        # tempo_config=TracingTempoConfig(
-        #     org_id="1",
-        #     datasource_uid=self._get_tempo_source_uid(),
-        #     url_format="grafana",
-        # ),
-        # )
 
         if grafana_internal_url and grafana_external_url:
             LOGGER.info(
@@ -234,6 +257,18 @@ class KialiCharm(ops.CharmBase):
                 enabled=True,
                 internal_url=grafana_internal_url,
                 external_url=grafana_external_url,
+            )
+
+        if tempo_configuration:
+            external_services.tracing = TracingConfig(
+                enabled=True,
+                internal_url=tempo_configuration["internal_url"],
+                external_url=tempo_configuration["external_url"],
+                tempo_config=TracingTempoConfig(
+                    org_id="1",
+                    datasource_uid=tempo_configuration["datasource_uid"],
+                    url_format="grafana",
+                ),
             )
 
         kiali_config = KialiConfigSpec(
@@ -271,14 +306,10 @@ class KialiCharm(ops.CharmBase):
         LOGGER.debug(f"Kiali layer: {layer}")
         return layer
 
-    def _get_grafana_urls(self) -> GrafanaUrls:
-        """Return the urls for the related Grafana.
+    def _get_grafana_metadata(self) -> GrafanaMetadataAppData:
+        """Return the metadata for the related Grafana.
 
-        This retrieves the grafana urls from the grafana-metadata relation, returning:
-        * internal_url: GrafanaMetadataAppData.direct_url
-        * external_url: GrafanaMetadataAppData.ingress_url
-
-        If GrafanaMetadataAppData.ingress_url is not available, it will default to GrafanaMetadataAppData.direct_url.
+        If ingress_url is not available, we default it to the direct_url.
 
         Raises:
           GrafanaMissingError: If no grafana is related to this application
@@ -292,13 +323,15 @@ class KialiCharm(ops.CharmBase):
         if not grafana_metadata:
             raise WaitingStatusError("Waiting on data over the grafana-metadata relation")
 
-        urls = GrafanaUrls(
-            internal_url=str(grafana_metadata.direct_url),
-            external_url=str(grafana_metadata.ingress_url or grafana_metadata.direct_url),
+        # Create the return object, including a default value for ingress_url
+        grafana_metadata = GrafanaMetadataAppData(
+            direct_url=grafana_metadata.direct_url,
+            ingress_url=grafana_metadata.ingress_url or grafana_metadata.direct_url,
+            grafana_uid=grafana_metadata.grafana_uid,
         )
 
-        LOGGER.debug(f"Grafana urls: {urls}")
-        return urls
+        LOGGER.debug(f"Grafana metadata: {grafana_metadata}")
+        return grafana_metadata
 
     def _get_istio_namespace(self) -> str:
         """Get the istio namespace configuration.
@@ -338,6 +371,88 @@ class KialiCharm(ops.CharmBase):
         returned = str(prometheus_data.ingress_url or prometheus_data.direct_url)
         LOGGER.debug(f"Prometheus source URL: {returned}")
         return returned
+
+    def _get_tempo_configuration(self, grafana_uid: str) -> Optional[TempoConfigurationData]:
+        """Return configuration data for the related Tempo.
+
+        This returns only the http api from tempo, not the grpc api, because Kiali only supports http.  If ingress_url
+        is not available, we default it to the direct_url.
+
+        Returns None if we are not related to a tempo.
+
+        Raises:
+          TempoMissingError: If no tempo is related to this application
+          BlockedStatusError: If a tempo is related to this application, but something else that is required is missing.
+          ConfigurationWaitingError: If a Tempo is related to this application, but its data sent from tempo or other
+                                     required relations is incomplete.
+        """
+        try:
+            tempo_metadata = self._get_tempo_api()
+        except TempoMissingError:
+            return None
+
+        tempo_datasource_uid = self._get_tempo_datasource_uid(grafana_uid=grafana_uid)
+
+        return TempoConfigurationData(
+            internal_url=str(tempo_metadata.http.direct_url).rstrip("/"),
+            external_url=str(
+                tempo_metadata.http.ingress_url or tempo_metadata.http.direct_url
+            ).rstrip("/"),
+            datasource_uid=tempo_datasource_uid,
+        )
+
+    def _get_tempo_api(self) -> TempoApiAppData:
+        """Get the Tempo api urls (internal and external).
+
+        Raises:
+            ConfigurationWaitingError: If a Tempo is related to this application, but its data is incomplete.
+        """
+        if len(self._tempo_api.relations) == 0:
+            raise TempoMissingError("No tempo available over the tempo-api relation")
+
+        tempo_metadata = self._tempo_api.get_data()
+        if not tempo_metadata:
+            raise WaitingStatusError("Waiting on related tempo application's metadata")
+
+        return tempo_metadata
+
+    def _get_tempo_datasource_uid(self, grafana_uid: str) -> str:
+        """Get the Tempo datasource uid.
+
+        Returns the first related datasource that is a tempo datasource and has the same grafana uid as the known
+        grafana.
+
+        Will raise:
+          ConfigurationBlockingError: If no applications are related, or applications are related but have sent only
+                                       non-tempo datasources
+          ConfigurationWaitingError: If a datasource is related, but has not yet provided data
+        """
+        if len(self.model.relations.get(TEMPO_DATASOURCE_EXCHANGE_RELATION, ())) == 0:
+            raise BlockedStatusError(
+                f"No tempo datasource available over the {TEMPO_DATASOURCE_EXCHANGE_RELATION} relation"
+            )
+
+        tempo_datasources = [
+            datasource
+            for datasource in self._tempo_datasource_exchange.received_datasources
+            if datasource.type == "tempo"
+        ]
+        if len(tempo_datasources) == 0:
+            WaitingStatusError("Tempo datasource relation exists, but no data has been provided")
+
+        if not grafana_uid:
+            raise BlockedStatusError(
+                "Tempo datasource relation exists, but no grafana metadata is available.  Add a relation to Grafana on"
+                " grafana-metadata unblock."
+            )
+
+        for datasource in tempo_datasources:
+            if datasource.grafana_uid == grafana_uid:
+                return datasource.uid
+        raise BlockedStatusError(
+            "Tempo datasources exist, but none match the related Grafana.  Check the that the "
+            "grafana-metadata relation is related to the same Grafana as Tempo."
+        )
 
     def _is_prometheus_source_available(self):
         """Return True if Prometheus is available, else False."""
@@ -419,6 +534,12 @@ class PrometheusSourceError(Exception):
 
 
 class GrafanaMissingError(Exception):
+    """Raised when the Grafana data is not available."""
+
+    pass
+
+
+class TempoMissingError(Exception):
     """Raised when the Grafana data is not available."""
 
     pass

--- a/src/charm.py
+++ b/src/charm.py
@@ -372,7 +372,7 @@ class KialiCharm(ops.CharmBase):
         LOGGER.debug(f"Prometheus source URL: {returned}")
         return returned
 
-    def _get_tempo_configuration(self, grafana_uid: str) -> Optional[TempoConfigurationData]:
+    def _get_tempo_configuration(self, grafana_uid: Optional[str]) -> Optional[TempoConfigurationData]:
         """Return configuration data for the related Tempo.
 
         This returns only the http api from tempo, not the grpc api, because Kiali only supports http.  If ingress_url
@@ -416,7 +416,7 @@ class KialiCharm(ops.CharmBase):
 
         return tempo_metadata
 
-    def _get_tempo_datasource_uid(self, grafana_uid: str) -> str:
+    def _get_tempo_datasource_uid(self, grafana_uid: Optional[str]) -> str:
         """Get the Tempo datasource uid.
 
         Returns the first related datasource that is a tempo datasource and has the same grafana uid as the known

--- a/src/charm.py
+++ b/src/charm.py
@@ -372,7 +372,9 @@ class KialiCharm(ops.CharmBase):
         LOGGER.debug(f"Prometheus source URL: {returned}")
         return returned
 
-    def _get_tempo_configuration(self, grafana_uid: Optional[str]) -> Optional[TempoConfigurationData]:
+    def _get_tempo_configuration(
+        self, grafana_uid: Optional[str]
+    ) -> Optional[TempoConfigurationData]:
         """Return configuration data for the related Tempo.
 
         This returns only the http api from tempo, not the grpc api, because Kiali only supports http.  If ingress_url

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Union
 
@@ -11,6 +12,38 @@ import yaml
 from lightkube.resources.core_v1 import Service
 
 logger = logging.getLogger(__name__)
+
+app_metadata = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+KIALI_NAME = app_metadata["name"]
+kiali_resources = {
+    "kiali-image": app_metadata["resources"]["kiali-image"]["upstream-source"],
+}
+
+
+@dataclass
+class CharmDeploymentConfiguration:
+    entity_url: str  # aka charm name or local path to charm
+    application_name: str
+    channel: str
+    trust: bool
+    config: Optional[dict] = None
+
+
+ISTIO_K8S = CharmDeploymentConfiguration(
+    entity_url="istio-k8s", application_name="istio-k8s", channel="latest/edge", trust=True
+)
+ISTIO_INGRESS_K8S = CharmDeploymentConfiguration(
+    entity_url="istio-ingress-k8s",
+    application_name="istio-ingress-k8s",
+    channel="latest/edge",
+    trust=True,
+)
+PROMETHEUS_K8S = CharmDeploymentConfiguration(
+    entity_url="prometheus-k8s",
+    application_name="prometheus-k8s",
+    channel="latest/edge",
+    trust=True,
+)
 
 
 def build_charm(

--- a/tests/integration/tempo_helpers.py
+++ b/tests/integration/tempo_helpers.py
@@ -1,0 +1,136 @@
+"""Test helpers for the Tempo integration tests.
+
+These are slightly modified from https://github.com/canonical/tempo-coordinator-k8s-operator/tree/main/tests/integration
+"""
+
+import copy
+from dataclasses import asdict
+
+from minio import Minio
+from ops import Application, Unit
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.helpers import CharmDeploymentConfiguration
+
+TEMPO_COORDINATOR_K8S = CharmDeploymentConfiguration(
+    entity_url="tempo-coordinator-k8s",
+    application_name="tempo-coordinator-k8s",
+    channel="latest/edge",
+    trust=True,
+)
+
+TEMPO_WORKER_K8S = CharmDeploymentConfiguration(
+    entity_url="tempo-worker-k8s",
+    application_name="tempo-worker-k8s",
+    channel="latest/edge",
+    trust=True,
+)
+
+S3_INTEGRATOR = CharmDeploymentConfiguration(
+    entity_url="s3-integrator",
+    application_name="s3-integrator",
+    channel="latest/edge",
+    trust=False,
+)
+
+MINIO = CharmDeploymentConfiguration(
+    entity_url="minio",
+    application_name="minio",
+    channel="latest/edge",
+    trust=True,
+)
+
+
+async def deploy_monolithic_cluster(ops_test: OpsTest):
+    """Deploy a monolithic tempo cluster."""
+    coordinator_name = TEMPO_COORDINATOR_K8S.application_name
+    worker_name = TEMPO_WORKER_K8S.application_name
+    s3_integrator_name = S3_INTEGRATOR.application_name
+
+    await ops_test.model.deploy(**asdict(TEMPO_COORDINATOR_K8S))
+    await ops_test.model.deploy(**asdict(TEMPO_WORKER_K8S))
+    await ops_test.model.deploy(**asdict(S3_INTEGRATOR))
+
+    await ops_test.model.integrate(
+        coordinator_name + ":s3", s3_integrator_name + ":s3-credentials"
+    )
+    await ops_test.model.integrate(
+        coordinator_name + ":tempo-cluster", worker_name + ":tempo-cluster"
+    )
+
+    access_key = "minio123"
+    secret_key = "minio123"
+    bucket_name = "tempo"
+
+    await deploy_and_configure_minio(
+        s3_integrator=s3_integrator_name,
+        access_key=access_key,
+        secret_key=secret_key,
+        bucket_name=bucket_name,
+        ops_test=ops_test,
+    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[coordinator_name, worker_name, s3_integrator_name],
+            status="active",
+            timeout=2000,
+            idle_period=30,
+        )
+
+    return coordinator_name
+
+
+async def deploy_and_configure_minio(
+    s3_integrator, access_key, secret_key, bucket_name, ops_test: OpsTest
+):
+    """Deploy and configure minio for tempo."""
+    minio_name = MINIO.application_name
+    config = {
+        "access-key": access_key,
+        "secret-key": secret_key,
+    }
+    minio_with_config = copy.deepcopy(MINIO)
+    minio_with_config.config = config
+
+    await ops_test.model.deploy(**asdict(minio_with_config))
+    await ops_test.model.wait_for_idle(apps=[minio_name], status="active", timeout=2000)
+    minio_addr = await get_unit_address(ops_test, minio_name, "0")
+
+    mc_client = Minio(
+        f"{minio_addr}:9000",
+        access_key=access_key,
+        secret_key=secret_key,
+        secure=False,
+    )
+
+    # create tempo bucket
+    found = mc_client.bucket_exists(bucket_name)
+    if not found:
+        mc_client.make_bucket(bucket_name)
+
+    # configure s3-integrator
+    s3_integrator_app: Application = ops_test.model.applications[s3_integrator]
+    s3_integrator_leader: Unit = s3_integrator_app.units[0]
+
+    await s3_integrator_app.set_config(
+        {
+            "endpoint": f"minio-0.minio-endpoints.{ops_test.model.name}.svc.cluster.local:9000",
+            "bucket": bucket_name,
+        }
+    )
+
+    action = await s3_integrator_leader.run_action("sync-s3-credentials", **config)
+    action_result = await action.wait()
+    assert action_result.status == "completed"
+
+
+async def get_unit_address(ops_test: OpsTest, app_name, unit_no):
+    """Return the address of the unit with the given name and unit number."""
+    status = await ops_test.model.get_status()
+    app = status["applications"][app_name]
+    if app is None:
+        assert False, f"no app exists with name {app_name}"
+    unit = app["units"].get(f"{app_name}/{unit_no}")
+    if unit is None:
+        assert False, f"no unit exists in app {app_name} with index {unit_no}"
+    return unit["address"]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,50 +3,21 @@
 # See LICENSE file for licensing details.
 
 import logging
-from dataclasses import asdict, dataclass
-from pathlib import Path
-from typing import Optional
+from dataclasses import asdict
 
 import pytest
 import requests
-import yaml
+from helpers import (
+    ISTIO_INGRESS_K8S,
+    ISTIO_K8S,
+    KIALI_NAME,
+    PROMETHEUS_K8S,
+    get_k8s_service_ip,
+    kiali_resources,
+)
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import get_k8s_service_ip
-
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-APP_NAME = METADATA["name"]
-resources = {
-    "kiali-image": METADATA["resources"]["kiali-image"]["upstream-source"],
-}
-
-
-@dataclass
-class CharmDeploymentConfiguration:
-    entity_url: str  # aka charm name or local path to charm
-    application_name: str
-    channel: str
-    trust: bool
-    config: Optional[dict] = None
-
-
-ISTIO_K8S = CharmDeploymentConfiguration(
-    entity_url="istio-k8s", application_name="istio-k8s", channel="latest/edge", trust=True
-)
-ISTIO_INGRESS_K8S = CharmDeploymentConfiguration(
-    entity_url="istio-ingress-k8s",
-    application_name="istio-ingress-k8s",
-    channel="latest/edge",
-    trust=True,
-)
-PROMETHEUS_K8S = CharmDeploymentConfiguration(
-    entity_url="prometheus-k8s",
-    application_name="prometheus-k8s",
-    channel="latest/edge",
-    trust=True,
-)
 
 
 @pytest.mark.setup
@@ -54,17 +25,17 @@ PROMETHEUS_K8S = CharmDeploymentConfiguration(
 async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
     """Build the charm_under_test and deploy it."""
     await ops_test.model.deploy(
-        charm_under_test, resources=resources, application_name=APP_NAME, trust=True
+        charm_under_test, resources=kiali_resources, application_name=KIALI_NAME, trust=True
     )
 
     # Charm will be blocked because it needs prometheus
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[KIALI_NAME], status="blocked", timeout=1000)
 
 
 @pytest.mark.setup
 @pytest.mark.dependency
 @pytest.mark.abort_on_fail
-async def test_deploy_dependencies(ops_test: OpsTest):
+async def test_deploy_required_dependencies(ops_test: OpsTest):
     """Deploy the integration test dependencies."""
     await ops_test.model.deploy(**asdict(ISTIO_K8S))
     await ops_test.model.deploy(**asdict(PROMETHEUS_K8S))
@@ -82,21 +53,21 @@ async def test_deploy_dependencies(ops_test: OpsTest):
 
 @pytest.mark.setup
 @pytest.mark.abort_on_fail
-async def test_add_relations_to_dependencies(ops_test: OpsTest):
+async def test_add_relations_to_required_dependencies(ops_test: OpsTest):
     """Relate the charm_under_test to prometheus and istio-k8s."""
     await ops_test.model.add_relation(
-        f"{APP_NAME}:prometheus", f"{PROMETHEUS_K8S.application_name}:prometheus-api"
+        f"{KIALI_NAME}:prometheus", f"{PROMETHEUS_K8S.application_name}:prometheus-api"
     )
-    await ops_test.model.add_relation(f"{APP_NAME}:istio-metadata", ISTIO_K8S.application_name)
+    await ops_test.model.add_relation(f"{KIALI_NAME}:istio-metadata", ISTIO_K8S.application_name)
 
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=60)
+    await ops_test.model.wait_for_idle(apps=[KIALI_NAME], status="active", timeout=60)
 
 
 @pytest.mark.abort_on_fail
 async def test_kiali_is_available(ops_test: OpsTest):
     """Assert that Kiali is up and available inside the cluster."""
     # Arrange - get the Kiali service IP
-    kiali_service_ip = get_k8s_service_ip(ops_test.model.name, APP_NAME)
+    kiali_service_ip = get_k8s_service_ip(ops_test.model.name, KIALI_NAME)
 
     # Assert that Kiali is available via the charm's service
     assert kiali_service_ip is not None, "Kiali service IP not found"
@@ -108,10 +79,10 @@ async def test_kiali_is_available(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_ingress_relation(ops_test: OpsTest):
     """Relate kiali to istio-ingress."""
-    await ops_test.model.add_relation(ISTIO_INGRESS_K8S.application_name, APP_NAME)
+    await ops_test.model.add_relation(ISTIO_INGRESS_K8S.application_name, KIALI_NAME)
 
     await ops_test.model.wait_for_idle(
-        apps=[ISTIO_INGRESS_K8S.application_name, APP_NAME],
+        apps=[ISTIO_INGRESS_K8S.application_name, KIALI_NAME],
         status="active",
         raise_on_blocked=True,
         timeout=1000,
@@ -128,7 +99,7 @@ async def test_ingress_is_available(ops_test: OpsTest):
 
     # Assert that Kiali is available via the ingress service
     assert ingress_ip is not None, "Ingress IP not found"
-    resp = requests.get(url=f"http://{ingress_ip}/{ops_test.model.name}-{APP_NAME}")
+    resp = requests.get(url=f"http://{ingress_ip}/{ops_test.model.name}-{KIALI_NAME}")
     assert resp.status_code == 200, "Kiali is not available"
 
 
@@ -136,6 +107,6 @@ async def test_ingress_is_available(ops_test: OpsTest):
 async def test_remove_relation_prometheus(ops_test: OpsTest):
     """Assert charm is blocked when we remove the prometheus relation."""
     await ops_test.model.applications[PROMETHEUS_K8S.application_name].remove_relation(
-        f"{APP_NAME}:prometheus", PROMETHEUS_K8S.application_name
+        f"{KIALI_NAME}:prometheus", PROMETHEUS_K8S.application_name
     )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[KIALI_NAME], status="blocked", timeout=1000)

--- a/tests/integration/test_tempo_integration.py
+++ b/tests/integration/test_tempo_integration.py
@@ -129,9 +129,7 @@ async def test_kiali_is_available(ops_test: OpsTest):
 #   tox -e integration -- --model kiali tests/integration/test_tempo_integration.py
 #   juju add-model bookinfo
 #   juju deploy istio-beacon-k8s --trust --channel edge --config model-on-mesh=true
-#   # TODO: Link below is pinned to release-1.25 because the default branch has a non-woke name that fails our woke
-#   #  linter... and we cannot add an ignore check to our woke linter :/  Feel free to use the default branch locally.
-#   kubectl -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.25/samples/bookinfo/platform/kube/bookinfo.yaml
+#   kubectl -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/bookinfo/platform/kube/bookinfo.yaml
 #   # Generate traffic:
 #   while true; do kubectl -n bookinfo exec "$(kubectl -n bookinfo get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS grafana-on-mesh:3000  | grep -o "<title>.*</title>"; sleep 1; done
 #   # Check in the Kiali dashboard for traces to the bookinfo app

--- a/tests/integration/test_tempo_integration.py
+++ b/tests/integration/test_tempo_integration.py
@@ -129,7 +129,9 @@ async def test_kiali_is_available(ops_test: OpsTest):
 #   tox -e integration -- --model kiali tests/integration/test_tempo_integration.py
 #   juju add-model bookinfo
 #   juju deploy istio-beacon-k8s --trust --channel edge --config model-on-mesh=true
-#   kubectl -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/bookinfo/platform/kube/bookinfo.yaml
+#   # TODO: Link below is pinned to release-1.25 because the default branch has a non-woke name that fails our woke
+#   #  linter... and we cannot add an ignore check to our woke linter :/  Feel free to use the default branch locally.
+#   kubectl -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/refs/heads/release-1.25/samples/bookinfo/platform/kube/bookinfo.yaml
 #   # Generate traffic:
 #   while true; do kubectl -n bookinfo exec "$(kubectl -n bookinfo get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS grafana-on-mesh:3000  | grep -o "<title>.*</title>"; sleep 1; done
 #   # Check in the Kiali dashboard for traces to the bookinfo app

--- a/tests/integration/test_tempo_integration.py
+++ b/tests/integration/test_tempo_integration.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from dataclasses import asdict
+
+import pytest
+from helpers import (
+    ISTIO_K8S,
+    KIALI_NAME,
+)
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.helpers import CharmDeploymentConfiguration
+from tests.integration.tempo_helpers import TEMPO_COORDINATOR_K8S, deploy_monolithic_cluster
+from tests.integration.test_charm import (
+    test_add_relations_to_required_dependencies as add_relations_to_required_dependencies,
+)
+from tests.integration.test_charm import test_build_and_deploy as build_and_deploy
+from tests.integration.test_charm import (
+    test_deploy_required_dependencies as deploy_required_dependencies,
+)
+from tests.integration.test_charm import test_kiali_is_available as kiali_is_available
+
+logger = logging.getLogger(__name__)
+TEMPO_NAME = TEMPO_COORDINATOR_K8S.application_name
+
+GRAFANA_K8S = CharmDeploymentConfiguration(
+    entity_url="grafana-k8s",
+    application_name="grafana-k8s",
+    channel="latest/edge",
+    trust=True,
+    config={
+        "allow_anonymous_access": "true",
+    },
+)
+GRAFANA_NAME = GRAFANA_K8S.application_name
+
+
+@pytest.mark.setup
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm_under_test):
+    """Build the charm_under_test and deploy it."""
+    await build_and_deploy(ops_test, charm_under_test)
+
+
+@pytest.mark.setup
+@pytest.mark.dependency
+@pytest.mark.abort_on_fail
+async def test_deploy_required_dependencies(ops_test: OpsTest):
+    """Deploy the integration test dependencies."""
+    await deploy_required_dependencies(ops_test)
+
+
+@pytest.mark.setup
+@pytest.mark.dependency
+@pytest.mark.abort_on_fail
+async def test_add_relations_to_required_dependencies(ops_test: OpsTest):
+    """Relate the charm_under_test to prometheus and istio-k8s."""
+    await add_relations_to_required_dependencies(ops_test)
+
+
+@pytest.mark.setup
+@pytest.mark.dependency
+@pytest.mark.abort_on_fail
+async def test_deploy_grafana(ops_test: OpsTest):
+    """Deploy grafana for integration with Kiali and Tempo."""
+    await ops_test.model.deploy(**asdict(GRAFANA_K8S))
+    await ops_test.model.wait_for_idle(
+        apps=[GRAFANA_K8S.application_name], status="active", timeout=1000
+    )
+
+
+@pytest.mark.setup
+@pytest.mark.dependency
+@pytest.mark.abort_on_fail
+async def test_deploy_tempo(ops_test: OpsTest):
+    """Deploy and configure a monolithic Tempo instance to integrate it to our existing dependencies for testing."""
+    await deploy_monolithic_cluster(ops_test)
+    await ops_test.model.add_relation(f"{TEMPO_NAME}:grafana-source", GRAFANA_NAME)
+
+    await ops_test.model.wait_for_idle(
+        apps=[TEMPO_NAME, GRAFANA_NAME, ISTIO_K8S.application_name], status="active", timeout=1000
+    )
+
+
+@pytest.mark.setup
+@pytest.mark.dependency
+@pytest.mark.abort_on_fail
+async def test_relate_istio_to_tempo(ops_test: OpsTest):
+    """Relate istio-k8s to tempo to configure workload tracing forwarding."""
+    await ops_test.model.add_relation(
+        f"{ISTIO_K8S.application_name}:workload-tracing", f"{TEMPO_NAME}:tracing"
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[ISTIO_K8S.application_name, TEMPO_NAME], status="active", timeout=1000
+    )
+
+
+@pytest.mark.setup
+@pytest.mark.dependency
+@pytest.mark.abort_on_fail
+async def test_add_relation_from_kiali_to_tempo_and_grafana(ops_test: OpsTest):
+    """Relate Kiali to tempo."""
+    await ops_test.model.add_relation(f"{KIALI_NAME}:tempo-api", f"{TEMPO_NAME}")
+    await ops_test.model.add_relation(
+        f"{KIALI_NAME}:tempo-datasource-exchange", f"{TEMPO_NAME}:receive-datasource"
+    )
+    await ops_test.model.add_relation(f"{KIALI_NAME}:grafana-metadata", f"{GRAFANA_NAME}")
+
+    await ops_test.model.wait_for_idle(
+        apps=[KIALI_NAME, TEMPO_NAME, GRAFANA_NAME], status="active", timeout=1000
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_kiali_is_available(ops_test: OpsTest):
+    """Assert that Kiali is up and available inside the cluster."""
+    await kiali_is_available(ops_test)
+
+
+# TODO: This confirms the charms assemble together, not that tracing is actually visible in Kiali.  Should we automate
+#  that?
+#
+#  To manually confirm this, execute the above tests, keep the model, deploy a workload, and inspect in Kiali:
+#   juju add-model kiali
+#   tox -e integration -- --model kiali tests/integration/test_tempo_integration.py
+#   juju add-model bookinfo
+#   juju deploy istio-beacon-k8s --trust --channel edge --config model-on-mesh=true
+#   kubectl -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/bookinfo/platform/kube/bookinfo.yaml
+#   # Generate traffic:
+#   while true; do kubectl -n bookinfo exec "$(kubectl -n bookinfo get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS grafana-on-mesh:3000  | grep -o "<title>.*</title>"; sleep 1; done
+#   # Check in the Kiali dashboard for traces to the bookinfo app
+#  Note that until https://github.com/canonical/istio-k8s-operator/issues/30 is resolved, we also need to do the
+#  following so istio can forward traces to tempo:
+#   cat << EOF | kubectl apply -n kiali -f -
+#   apiVersion: networking.istio.io/v1alpha3
+#   kind: ServiceEntry
+#   metadata:
+#     name: tempo
+#   spec:
+#     hosts:
+#     - tempo-coordinator-k8s-0.tempo-coordinator-k8s-endpoints.kiali.svc.cluster.local
+#     ports:
+#     - number: 4317
+#       name: grpc-otel
+#       protocol: GRPC
+#     resolution: DNS
+#   EOF

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -4,6 +4,7 @@
 from unittest.mock import patch
 
 import pytest
+from charms.tempo_coordinator_k8s.v0.tempo_api import TempoApiRequirer
 from scenario import Context
 
 from charm import KialiCharm as ThisCharm
@@ -11,7 +12,9 @@ from charm import KialiCharm as ThisCharm
 
 @pytest.fixture(scope="function")
 def this_charm():
-    yield ThisCharm
+    with patch.object(TempoApiRequirer, "_validate_relation_metadata", return_value=None):
+        # This validation step always fails in CI because it checks a metadata.yaml and we don't have one.
+        yield ThisCharm
 
 
 @pytest.fixture(scope="function")

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ deps =
     pytest-asyncio==0.21.2
     juju
     lightkube
+    minio
     pytest-operator
     requests
     -r {toxinidir}/requirements.txt


### PR DESCRIPTION
## Solution
This adds integration between tempo and kiali using the tempo-api and grafana-datasource-exchange relations to communicate the configurations.  Also added here are integration tests that assert the charms can be connected and go to active

This PR has been manually tested to demonstrate that traces actually show up in the Kiali UI.  Not included here are automated tests that prove this, as it would require a lot of interacting with the Kiali UI programmatically.  Instructions for manual testing have been included in the test_tempo_integration.py file [here](https://github.com/canonical/kiali-k8s-operator/pull/47/files#diff-4b3fe3aff81cf5b653dd6731d39845b6b37eef537ff2b505443b9367f78ef471R124-R151) (I'm flexible on whether it should be in comments in the code, or if we should put it somewhere else)

## Context
Closes #28 and #29 

## Testing Instructions
See [here](https://github.com/canonical/kiali-k8s-operator/pull/47/files#diff-4b3fe3aff81cf5b653dd6731d39845b6b37eef537ff2b505443b9367f78ef471R124-R151) for manual test instructions

## Upgrade Notes
-