### PR TITLE
docs: add docs links to charmcraft.yaml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing
 ![GitHub License](https://img.shields.io/github/license/canonical/kiali-k8s-operator)
 ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/y/canonical/kiali-k8s-operator)
-![GitHub Lines of Code](https://img.shields.io/tokei/lines/github/canonical/kiali-k8s-operator)
 ![GitHub Issues](https://img.shields.io/github/issues/canonical/kiali-k8s-operator)
 ![GitHub PRs](https://img.shields.io/github/issues-pr/canonical/kiali-k8s-operator)
 ![GitHub Contributors](https://img.shields.io/github/contributors/canonical/kiali-k8s-operator)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# kiali-k8s-operator
+# Kiali Charmed Operator for Kubernetes
+
+[![CharmHub Badge](https://charmhub.io/kiali-k8s/badge.svg)](https://charmhub.io/kiali-k8s)
+[![Release](https://github.com/canonical/kiali-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/kiali-k8s-operator/actions/workflows/release.yaml)
+
+`kiali-k8s` is a charm for [Kiali](Kiali), a dashboard for [Istio](Istio).  It is a useful but non-essential tool to help someone administer their Istio service mesh.
+
+This Charmed Operator handles deployment, scaling, configuration, and Day 2 operations specific to Kiali, and offers simple integrations to observe [Charmed Istio][Istio charm] and be observed by the [Charmed Observability Stack][COS Docs].
+
+## Usage
+
+See [the Kiali charm documentation](https://charmhub.io/kiali-k8s) for details on how to deploy and configure the Kiali Charmed Operator.
+
+## Contributing
+
+We welcome contributions to the Kiali Charmed Operator.  Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,6 +8,12 @@ summary: A Juju charm to operate Kiali
 description: |
   Kiali is a dashboard for Istio, providing visualization and control of your service mesh.
 
+links:
+  documentation: https://discourse.charmhub.io/t/kiali-index/17247
+  website: https://charmhub.io/kiali-k8s
+  source: https://github.com/canonical/kiali-k8s-operator
+  issues: https://github.com/canonical/kiali-k8s-operator/issues
+
 assumes:
   - k8s-api
 


### PR DESCRIPTION
## Issue
#42

## Solution
Adds links to discourse/charmhub documentation to the charm and readme


## Context
Closes #42

## Testing Instructions
None

## Upgrade Notes
None