### PR TITLE
fix: shut down workload when configuration is not available

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -211,7 +211,14 @@ class KialiCharm(ops.CharmBase):
             raise WaitingStatusError("Container is not ready, cannot configure Kiali")
 
         if not new_config:
-            LOGGER.debug("No new_config provided.  raising Blocked StatusError.")
+            try:
+                self._container.stop(KIALI_PEBBLE_SERVICE_NAME)
+            except ops.pebble.APIError:
+                # Layer likely doesn't exist yet.  Ignoring
+                pass
+            LOGGER.debug(
+                "No new_config provided.  Stopping the container and raising Blocked StatusError."
+            )
             raise BlockedStatusError("No configuration available for Kiali")
 
         layer = self._generate_kiali_layer()

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from observability_charm_tools.exceptions import BlockedStatusError, WaitingStatusError
 from ops import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.pebble import Layer
 from scenario import Container, Relation, State
 
 from charm import KialiCharm, TempoConfigurationData
@@ -134,7 +135,11 @@ def mock_is_kiali_available(raises: Optional[Exception]):
         ),
         (
             # Inactive - prometheus relation not ready
-            Container(name="kiali", can_connect=True),
+            Container(
+                name="kiali",
+                can_connect=True,
+                layers={"kiali": Layer({"services": {"kiali": {"summary": "kiali"}}})},
+            ),
             [
                 mock_istio_metadata_relation(),
             ],
@@ -143,7 +148,11 @@ def mock_is_kiali_available(raises: Optional[Exception]):
         ),
         (
             # Inactive - istio-metadata relation not ready
-            Container(name="kiali", can_connect=True),
+            Container(
+                name="kiali",
+                can_connect=True,
+                layers={"kiali": Layer({"services": {"kiali": {"summary": "kiali"}}})},
+            ),
             [
                 mock_istio_metadata_relation(),
             ],


### PR DESCRIPTION
## Issue
Closes #48


## Solution
This PR makes the charm shut down the kiali service whenever configuration is unavailable


## Context
#48

## Testing Instructions
Deploy kiali and add required relations
wait for the workload to be up and test it in a browser
`juju remove-relation kiali-k8s prometheus-k8s` to remove a required relation
workload should be shut down and kiali not reachable in the browser

## Upgrade Notes
.