### PR TITLE
remove `integration` from the tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 skip_missing_interpreters = True
-envlist = lint, static-{charm}, unit, scenario, integration
+envlist = lint, static-{charm}, unit, scenario
 
 [vars]
 src_path = {toxinidir}/src


### PR DESCRIPTION
This means that running `tox` without envs gives you all the quick-running tests, which is a nice dev experience