### PR TITLE
ci(release): remove legacy input build-for-arm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,5 @@ jobs:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v1
     secrets: inherit
     with:
-      build-for-arm: true
       default-track: 1
 


### PR DESCRIPTION
The release workflow failed because the input `build-for-arm` have been removed in ci v1. Hence its been removed from the inputs. 
