### PR TITLE
feat: add tf module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,38 @@ tests/integration/*-tester/lib/
 .env
 .vscode/
 *.egg-info
+
+
+## Terraform
+# Local .terraform directories
+.terraform/
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+*.lock.hcl
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,66 @@
+<!-- BEGIN_TF_DOCS -->
+# Kiali K8s Terraform Module
+
+This is a Terraform module facilitating the deployment of kiali-k8s, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+For detailed information on Kiali and Canonical Service Mesh, see the [official documentation](https://canonical-service-mesh-documentation.readthedocs-hosted.com/en/latest/).
+
+## Usage
+
+Create `main.tf`:
+
+```hcl
+module "kiali" {
+  source  = "git::https://github.com/canonical/kiali-k8s-operator//terraform"
+  model   = juju_model.k8s.name
+  channel = "1/edge"
+}
+```
+
+```sh
+$ terraform apply
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.14.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.14.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [juju_application.this_app](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"kiali"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,39 @@
+/**
+ * # Kiali K8s Terraform Module
+ *
+ * This is a Terraform module facilitating the deployment of kiali-k8s, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+ *
+ * For detailed information on Kiali and Canonical Service Mesh, see the [official documentation](https://canonical-service-mesh-documentation.readthedocs-hosted.com/en/latest/).
+ *
+ * ## Usage
+ *
+ * Create `main.tf`:
+ *
+ * ```hcl
+ * module "kiali" {
+ *   source  = "git::https://github.com/canonical/kiali-k8s-operator//terraform"
+ *   model   = juju_model.k8s.name
+ *   channel = "1/edge"
+ * }
+ * ```
+ *
+ * ```sh
+ * $ terraform apply
+ * ```
+ */
+
+resource "juju_application" "this_app" {
+  name               = var.app_name
+  config             = var.config
+  constraints        = var.constraints
+  model              = var.model
+  storage_directives = var.storage_directives
+  trust              = true
+  units              = var.units
+
+  charm {
+    name     = "kiali-k8s"
+    channel  = var.channel
+    revision = var.revision
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,22 @@
+output "app_name" {
+  value = juju_application.this_app.name
+}
+
+output "endpoints" {
+  value = {
+    # Requires
+    grafana-metadata = "grafana-metadata"
+    ingress          = "ingress"
+    istio-metadata   = "istio-metadata"
+    logging          = "logging"
+    prometheus-api   = "prometheus-api"
+    require-cmr-mesh = "require-cmr-mesh"
+    service-mesh     = "service-mesh"
+    tempo-api        = "tempo-api"
+
+    # Provides
+    metrics-endpoint          = "metrics-endpoint"
+    provide-cmr-mesh          = "provide-cmr-mesh"
+    tempo-datasource-exchange = "tempo-datasource-exchange"
+  }
+}

--- a/terraform/tests/example/kiali.tf
+++ b/terraform/tests/example/kiali.tf
@@ -84,12 +84,12 @@ resource "juju_integration" "kiali_prometheus" {
   model = juju_model.kiali_test.name
 
   application {
-    name = module.kiali.app_name
+    name     = module.kiali.app_name
     endpoint = module.kiali.endpoints.prometheus-api
   }
 
   application {
-    name = module.prometheus.app_name
+    name     = module.prometheus.app_name
     endpoint = module.prometheus.endpoints.prometheus_api
   }
 }
@@ -98,12 +98,12 @@ resource "juju_integration" "kiali_istio_metadata" {
   model = juju_model.kiali_test.name
 
   application {
-    name = module.kiali.app_name
+    name     = module.kiali.app_name
     endpoint = module.kiali.endpoints.istio-metadata
   }
 
   application {
-    name = module.istio.app_name
+    name     = module.istio.app_name
     endpoint = module.istio.endpoints.istio_metadata
   }
 }

--- a/terraform/tests/example/kiali.tf
+++ b/terraform/tests/example/kiali.tf
@@ -1,0 +1,120 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0"
+    }
+  }
+}
+
+provider "juju" {
+  # These values can be set through environment variables:
+  # JUJU_CONTROLLER_ADDRESSES - controller endpoint
+  # JUJU_USERNAME - username
+  # JUJU_PASSWORD - password
+  # JUJU_CA_CERT - CA certificate
+
+  # Or you can specify them explicitly:
+  # controller_addresses = "10.0.0.1:17070"
+  # username = "admin"
+  # password = "your-password"
+  # ca_certificate = file("~/juju-ca-cert.crt")
+}
+
+# Create a model for testing
+resource "juju_model" "kiali_test" {
+  name = "kiali-test"
+
+  # Specify your cloud/substrate
+  # For example, for microk8s:
+  # cloud {
+  #   name = "microk8s"
+  # }
+
+  # For other Kubernetes clouds, adjust accordingly
+}
+
+# Deploy Istio using the istio-k8s-operator module
+module "istio" {
+  source   = "git::https://github.com/canonical/istio-k8s-operator//terraform"
+  model    = juju_model.kiali_test.name
+  channel  = "2/edge"
+  app_name = "istio"
+  units    = 1
+}
+
+# Deploy Prometheus using the prometheus-k8s-operator module
+module "prometheus" {
+  source   = "git::https://github.com/canonical/prometheus-k8s-operator//terraform"
+  model    = juju_model.kiali_test.name
+  channel  = "2/edge"
+  app_name = "prometheus"
+  units    = 1
+}
+
+# Deploy Istio Ingress using the module (depends on Istio being deployed first)
+module "kiali" {
+  source = "../.."
+
+  # Required: reference to the model
+  model = juju_model.kiali_test.name
+
+  # Required: specify the channel
+  channel = "2/edge"
+
+  # Optional: customize the deployment
+  app_name = "kiali"
+  units    = 1
+
+  # Optional: charm configuration
+  config = {
+    # Toggle whether Kiali is view-only
+    view-only-mode = true
+  }
+
+  # Optional: constraints
+  constraints = "arch=amd64"
+
+  # Ensure Istio is deployed before the ingress
+  depends_on = [module.istio]
+}
+
+resource "juju_integration" "kiali_prometheus" {
+  model = juju_model.kiali_test.name
+
+  application {
+    name = module.kiali.app_name
+    endpoint = module.kiali.endpoints.prometheus-api
+  }
+
+  application {
+    name = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.prometheus_api
+  }
+}
+
+resource "juju_integration" "kiali_istio_metadata" {
+  model = juju_model.kiali_test.name
+
+  application {
+    name = module.kiali.app_name
+    endpoint = module.kiali.endpoints.istio-metadata
+  }
+
+  application {
+    name = module.istio.app_name
+    endpoint = module.istio.endpoints.istio_metadata
+  }
+}
+
+# Outputs to verify deployment
+output "kiali_app_name" {
+  value       = module.kiali.app_name
+  description = "The name of the deployed application"
+}
+
+output "kiali_endpoints" {
+  value       = module.kiali.endpoints
+  description = "Available endpoints for the application"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "app_name" {
+  description = "Name to give the deployed application"
+  type        = string
+  default     = "kiali"
+}
+
+variable "channel" {
+  description = "Channel that the charm is deployed from"
+  type        = string
+}
+
+variable "config" {
+  description = "Map of the charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application"
+  type        = string
+  default     = ""
+}
+
+variable "model" {
+  description = "Reference to an existing model resource or data source for the model to deploy to"
+  type        = string
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Map of storage used by the application, which defaults to 1 GB, allocated by Juju"
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Unit count/scale"
+  type        = number
+  default     = 1
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,7 +18,7 @@ variable "config" {
 variable "constraints" {
   description = "String listing constraints for this application"
   type        = string
-  default     = ""
+  default     = "arch=amd64"
 }
 
 variable "model" {

--- a/terraform/version.tf
+++ b/terraform/version.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0"
+    }
+  }
+}

--- a/terraform/version.tf
+++ b/terraform/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.21.0"
     }
   }
 }


### PR DESCRIPTION
## Solution
Adds a terraform module for the charm.

The README.md for the terraform module is autogenerated using the header from main.tf by [terraform-docs](https://github.com/terraform-docs/terraform-docs) using:

```
sudo snap install terraform-docs
cd terraform
terraform-docs markdown table --output-file README.md . 
```
