### PR TITLE
feat(terraform): add channel validation and split outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Terraform
+**/.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,48 +1,20 @@
 <!-- BEGIN_TF_DOCS -->
-# Kiali K8s Terraform Module
-
-This is a Terraform module facilitating the deployment of kiali-k8s, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
-
-For detailed information on Kiali and Canonical Service Mesh, see the [official documentation](https://canonical-service-mesh-documentation.readthedocs-hosted.com/en/latest/).
-
-## Usage
-
-Create `main.tf`:
-
-```hcl
-module "kiali" {
-  source  = "git::https://github.com/canonical/kiali-k8s-operator//terraform"
-  model   = juju_model.k8s.name
-  channel = "1/edge"
-}
-```
-
-```sh
-$ terraform apply
-```
-
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.14.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.14.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
 
 ## Modules
 
 No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [juju_application.this_app](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 
 ## Inputs
 
@@ -52,7 +24,7 @@ No modules.
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
 | <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
-| <a name="input_model"></a> [model](#input\_model) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
 | <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
 | <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
 | <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
@@ -62,5 +34,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
-| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,9 +2,16 @@ output "app_name" {
   value = juju_application.kiali.name
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Requires
+    metrics-endpoint          = "metrics-endpoint"
+    provide-cmr-mesh          = "provide-cmr-mesh"
+    tempo-datasource-exchange = "tempo-datasource-exchange"
+  }
+}
+
+output "requires" {
+  value = {
     grafana-metadata = "grafana-metadata"
     ingress          = "ingress"
     istio-metadata   = "istio-metadata"
@@ -13,10 +20,5 @@ output "endpoints" {
     require-cmr-mesh = "require-cmr-mesh"
     service-mesh     = "service-mesh"
     tempo-api        = "tempo-api"
-
-    # Provides
-    metrics-endpoint          = "metrics-endpoint"
-    provide-cmr-mesh          = "provide-cmr-mesh"
-    tempo-datasource-exchange = "tempo-datasource-exchange"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

Split the  output into separate  and  outputs.

See canonical/alertmanager-k8s-operator#403 and canonical/alertmanager-k8s-operator#396 for reference.